### PR TITLE
Changed default scaling of textures (right panel) to keep aspect ratio

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-  	<script src="https://cdn.jsdelivr.net/npm/konva@8.4.3/konva.min.js"></script>
+  	<script src="https://cdn.jsdelivr.net/npm/konva@10.0.12/konva.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/numeric/1.2.6/numeric.min.js"></script>
     
     <script src="scripts/jquery.min.js"></script>

--- a/scripts/polygonManager.js
+++ b/scripts/polygonManager.js
@@ -8,7 +8,8 @@ const PolygonManager = {
             _id: Utils.generateId()
         });
 
-        if (group && group._id) dirtyPolygons.add(group._id);
+        if (group && group._id)
+            dirtyPolygons.add(group._id);
         
         // Get vertices - either from provided points or create default rectangle
         let vertices;

--- a/scripts/rightPanelManager.js
+++ b/scripts/rightPanelManager.js
@@ -52,6 +52,7 @@ const RightPanelManager = {
         // Transformer for selection
         const tr = new Konva.Transformer({
             keepRatio: true,
+            shiftBehavior: 'inverted',
             rotateEnabled: true,
             rotationSnaps: [0, 90, 180, 270],
             rotationSnapTolerance: 5,

--- a/scripts/rightPanelManager.js
+++ b/scripts/rightPanelManager.js
@@ -51,7 +51,7 @@ const RightPanelManager = {
 
         // Transformer for selection
         const tr = new Konva.Transformer({
-            keepRatio: false,
+            keepRatio: true,
             rotateEnabled: true,
             rotationSnaps: [0, 90, 180, 270],
             rotationSnapTolerance: 5,

--- a/scripts/use-konva-snapping.js
+++ b/scripts/use-konva-snapping.js
@@ -158,9 +158,9 @@ const useKonvaSnapping = (params) => {
         const { snapRange } = defaultParams;
 
         let { horizontal, vertical } = getSnappingPoints(e);
-        if(!e.currentTarget.keepRatio() || (e.currentTarget.keepRatio() && !!!oppositeAnchors[e.currentTarget._movingAnchorName])){
+        const keepRatio = !e.evt.shiftKey ? e.currentTarget.keepRatio() : ! e.currentTarget.keepRatio();
+        if(!keepRatio || (keepRatio && !!!oppositeAnchors[e.currentTarget._movingAnchorName])){
             e.currentTarget.anchorDragBoundFunc((oldAbsPos, newAbsPos, event) => {
-                //console.log(e.target)
        
                 Layer.find(".guid-line").forEach((line) => line.destroy());
                         let bounds = { x: newAbsPos.x, y: newAbsPos.y };


### PR DESCRIPTION
So with this change, scaling textures using by clicking a corner vertex will retain the aspect ratio, while scaling using a vertex at the center of any of the edges will scale it along the apropriate axis. 

I think this is a good change because:
- I feel like in most cases, people will want to keep the aspect ratio from the source image
- Users can scale images with and without retaining the aspect ratio without using the keyboard
- Users are more likely to experiment with the corner and edge vertices before they discover holding SHIFT while scaling preserves aspect ratio

closes #13 

@raycastly cc: @MickL