### PR TITLE
feat: pan with shift and lmb/trackpad

### DIFF
--- a/scripts/panZoomManager.js
+++ b/scripts/panZoomManager.js
@@ -7,7 +7,7 @@ const PanZoomManager = {
         let lastPos = { x: 0, y: 0 };
 
         stage.on("mousedown", (e) => {
-            if (e.evt.button === 1) { // Middle click
+            if (e.evt.button === 1 || (e.evt.button === 0 && e.evt.shiftKey)) { // Middle  click or shift + left click
                 PanZoomManager.isPanning = true;
                 lastPos = stage.getPointerPosition();
                 e.evt.preventDefault();

--- a/scripts/selectionManager.js
+++ b/scripts/selectionManager.js
@@ -8,6 +8,10 @@ const SelectionManager = {
         stage.on('mousedown', (e) => {
             // Only left mouse button for selection
             if (e.evt.button !== 0) return;
+			
+			// Disable selection if shift key is pressed
+			// since shift + LMB is used for panning
+			if (e.evt.shiftKey) return;
             
             // Don't start selection if clicking on an image or transformer
             if (e.target !== stage && e.target.name() !== 'bgRect') return;


### PR DESCRIPTION
This commit introduces new ways to pan using devices that don't feature a middle mouse button. Press and hold the shift key while you use your trackpad or left mouse button to pan the canvas.