### PR TITLE
feat: add auto-pack for left panel source images

### DIFF
--- a/css/better-ui.css
+++ b/css/better-ui.css
@@ -300,6 +300,10 @@ label {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 18 18' fill='%2337b8fb'%3E%3Cpath d='M5.828 10.172a.5.5 0 0 0-.707 0l-4.096 4.096V11.5a.5.5 0 0 0-1 0v3.975a.5.5 0 0 0 .5.5H4.5a.5.5 0 0 0 0-1H1.732l4.096-4.096a.5.5 0 0 0 0-.707m4.344-4.344a.5.5 0 0 0 .707 0l4.096-4.096V4.5a.5.5 0 1 0 1 0V.525a.5.5 0 0 0-.5-.5H11.5a.5.5 0 0 0 0 1h2.768l-4.096 4.096a.5.5 0 0 0 0 .707'/%3E%3C/svg%3E");
 }
 
+#autoPackLeft::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-grid-1x2-fill' viewBox='0 0 16 16'%3E%3Cpath d='M0 1a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1zm9 0a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1h-5a1 1 0 0 1-1-1zm0 9a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1h-5a1 1 0 0 1-1-1z'/%3E%3C/svg%3E");
+}
+
 #autoPack::before {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='white' class='bi bi-grid-1x2-fill' viewBox='0 0 16 16'%3E%3Cpath d='M0 1a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H1a1 1 0 0 1-1-1zm9 0a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1h-5a1 1 0 0 1-1-1zm0 9a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5a1 1 0 0 1-1 1h-5a1 1 0 0 1-1-1z'/%3E%3C/svg%3E");
 }

--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
                 <button id="addRectLeft" class="btn btn-sm btn-primary button-with-shortcut" data-shortcut="S">Add Rectangle</button>
                 <button id="deleteObjLeft" class="btn btn-sm btn-danger button-with-shortcut" data-shortcut="X">Delete Selected</button>
                 <div style="flex: 1"></div>
+                <button id="autoPackLeft" class="btn btn-sm btn-info">Auto Pack Images</button>
                 <button id="extractAllLeft" class="btn btn-sm btn-success button-with-shortcut" data-shortcut="D">Extract All</button>
             </div>
         </div>

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -70,7 +70,8 @@ const CONFIG = {
     SHORTCUTS: {
         uploadImage: 'KeyQ',
         toggleImageLock: 'KeyW',
-        
+        autoPackLeft: 'KeyE',
+
         toggleDrawingMode: 'KeyA',
         addRectangle: 'KeyS',
 

--- a/scripts/leftPanelManager.js
+++ b/scripts/leftPanelManager.js
@@ -358,6 +358,65 @@ const LeftPanelManager = {
         PanZoomManager.initPanning(stage);
         PanZoomManager.initZooming(stage);
 
+        window.leftPanel = {
+            autoPackImages: () => {
+                if (bgImages.length === 0) return;
+
+                const padding = 10;
+                const getDims = (img) => ({
+                    width: img.width() * Math.abs(img.scaleX()),
+                    height: img.height() * Math.abs(img.scaleY())
+                });
+
+                const sorted = [...bgImages].sort((a, b) => {
+                    return getDims(b).height - getDims(a).height;
+                });
+
+                let totalArea = 0;
+                sorted.forEach(img => {
+                    const d = getDims(img);
+                    totalArea += d.width * d.height;
+                });
+                const targetRowWidth = Math.max(
+                    stage.width(),
+                    Math.sqrt(totalArea) * 1.4
+                );
+
+                let cursorX = 0;
+                let cursorY = 0;
+                let rowHeight = 0;
+
+                sorted.forEach(img => {
+                    const { width, height } = getDims(img);
+                    if (cursorX > 0 && cursorX + width > targetRowWidth) {
+                        cursorX = 0;
+                        cursorY += rowHeight + padding;
+                        rowHeight = 0;
+                    }
+                    img.position({ x: cursorX, y: cursorY });
+                    cursorX += width + padding;
+                    rowHeight = Math.max(rowHeight, height);
+                });
+
+                tr.nodes([]);
+
+                const viewWidth = stage.width();
+                const viewHeight = stage.height();
+                const layoutWidth = targetRowWidth;
+                const layoutHeight = cursorY + rowHeight;
+                const scale = Math.min(
+                    viewWidth / (layoutWidth + padding * 2),
+                    viewHeight / (layoutHeight + padding * 2),
+                    1
+                );
+                stage.scale({ x: scale, y: scale });
+                stage.position({ x: padding * scale, y: padding * scale });
+
+                bgLayer.batchDraw();
+                FeedbackManager.show('Arranged ' + bgImages.length + ' image(s)');
+            }
+        };
+
         return stage;
     }
 };

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -38,6 +38,10 @@ document.addEventListener('DOMContentLoaded', () => {
         RightPanelManager.autoPackTextures(stageRight, false);
     });
 
+    document.getElementById('autoPackLeft').addEventListener('click', () => {
+        if (window.leftPanel) window.leftPanel.autoPackImages();
+    });
+
     // Export button
     document.getElementById('exportRight').addEventListener('click', () => {
         const exportWidth = parseInt(document.getElementById('rightWidth').value);

--- a/scripts/shortcutsManager.js
+++ b/scripts/shortcutsManager.js
@@ -48,4 +48,10 @@ document.addEventListener('keydown', (e) => {
         document.getElementById('autoPack').click();
         e.preventDefault();
     }
+
+    // Pack source textures
+    else if (e.code === CONFIG.SHORTCUTS.autoPackLeft) {
+        document.getElementById('autoPackLeft').click();
+        e.preventDefault();
+    }
 });


### PR DESCRIPTION
## Summary
- New "Auto Pack Images" button in left panel toolbar
- Shelf packing arranges all source images with no overlap
- Zoom-to-fit after packing to show all arranged images

## Test plan
- [x] Button arranges all uploaded images with no overlap
- [x] Works with different image sizes and counts
- [x] Zoom adjusts to show all packed images

🤖 Generated with [Claude Code](https://claude.com/claude-code)