### PR TITLE
feat: link rects to images toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
 
                 <button id="lockImagesLeft" class="btn btn-sm btn-success button-with-shortcut" data-shortcut="W" data-bs-toggle="tooltip" data-bs-title="Lock Images"></button>
                 <button id="autoPackLeft" class="btn btn-sm btn-info button-with-shortcut" data-shortcut="E" data-bs-toggle="tooltip" data-bs-title="Auto Pack Source Images"></button>
+                <label class="ms-2" style="font-size:0.8rem;">
+                    <input type="checkbox" id="linkRectsToImages" /> Link Rects
+                </label>
                 <div class="instruction">
                     Tip: You can also paste images from clipboard (Ctrl+V)
                 </div>

--- a/index.html
+++ b/index.html
@@ -20,8 +20,9 @@
 
                 <button id="lockImagesLeft" class="btn btn-sm btn-success button-with-shortcut" data-shortcut="W" data-bs-toggle="tooltip" data-bs-title="Lock Images"></button>
                 <button id="autoPackLeft" class="btn btn-sm btn-info button-with-shortcut" data-shortcut="E" data-bs-toggle="tooltip" data-bs-title="Auto Pack Source Images"></button>
-                <label class="ms-2" style="font-size:0.8rem;">
-                    <input type="checkbox" id="linkRectsToImages" /> Link Rects
+                <label class="icon-checkbox" data-bs-toggle="tooltip" data-bs-title="Link Rects to Images">
+                  <input type="checkbox" id="linkRectsToImages">
+                  <i class="bi bi-link"></i>
                 </label>
                 <div class="instruction">
                     Tip: You can also paste images from clipboard (Ctrl+V)

--- a/index.html
+++ b/index.html
@@ -20,6 +20,9 @@
                 <input type="file" id="bgUploadLeft" accept="image/*" style="display:none;">
 
                 <button id="lockImagesLeft" class="btn btn-sm btn-success button-with-shortcut" data-shortcut="W">Lock Images</button>
+                <label class="ms-2" style="font-size:0.8rem;">
+                    <input type="checkbox" id="linkRectsToImages" /> Link Rects
+                </label>
                 <div class="instruction">
                     Tip: You can also paste images from clipboard (Ctrl+V)
                 </div>

--- a/index.html
+++ b/index.html
@@ -24,9 +24,6 @@
                   <input type="checkbox" id="linkRectsToImages">
                   <i class="bi bi-link"></i>
                 </label>
-                <div class="instruction">
-                    Tip: You can also paste images from clipboard (Ctrl+V)
-                </div>
                 <div style="flex: 1"></div>
                 <button id="undo" class="btn btn-sm btn-success button-with-shortcut" data-shortcut="CTRL+Z" data-bs-toggle="tooltip" data-bs-title="Undo"></button>
                 <button id="redo" class="btn btn-sm btn-success button-with-shortcut" data-shortcut="CTRL+Y" data-bs-toggle="tooltip" data-bs-title="Redo"></button>

--- a/scripts/leftPanelManager.js
+++ b/scripts/leftPanelManager.js
@@ -25,6 +25,27 @@ const LeftPanelManager = {
         let drawingMode = false;
         let drawingModeHandlers = null;
 
+        let linkRectsToImages = false;
+
+        document.getElementById('linkRectsToImages').addEventListener('change', (e) => {
+            linkRectsToImages = e.target.checked;
+        });
+
+        function getOverlappingGroups(konvaImg) {
+            const imgBox = konvaImg.getClientRect();
+            const groups = [];
+            polygonLayer.find('.group').forEach(group => {
+                const groupBox = group.getClientRect();
+                if (imgBox.x + imgBox.width > groupBox.x &&
+                    imgBox.x < groupBox.x + groupBox.width &&
+                    imgBox.y + imgBox.height > groupBox.y &&
+                    imgBox.y < groupBox.y + groupBox.height) {
+                    groups.push(group);
+                }
+            });
+            return groups;
+        }
+
         // Helper to create a background image with undo support
         function addBackgroundImage(img) {
             const scale = Math.min(stage.width() / img.width, stage.height() / img.height);
@@ -394,23 +415,69 @@ const LeftPanelManager = {
         });
         uiLayer.add(tr);
 
-        // Image drag undo (stage-level events)
+        // Image drag undo (stage-level events) + optional linked-rect dragging
         let imgDragStartPos = null;
+        let imgDragLastPos = null;
+        let imgLinkedGroups = [];
+        let imgLinkedGroupStartPositions = [];
 
         stage.on('dragstart', (e) => {
             if (!(e.target instanceof Konva.Image)) return;
-            imgDragStartPos = { x: e.target.x(), y: e.target.y() };
+            const img = e.target;
+            imgDragStartPos = { x: img.x(), y: img.y() };
+            imgDragLastPos = { x: img.x(), y: img.y() };
+            if (linkRectsToImages) {
+                imgLinkedGroups = getOverlappingGroups(img);
+                imgLinkedGroupStartPositions = imgLinkedGroups.map(g => ({
+                    group: g, x: g.x(), y: g.y()
+                }));
+            } else {
+                imgLinkedGroups = [];
+                imgLinkedGroupStartPositions = [];
+            }
         });
+
+        stage.on('dragmove', (e) => {
+            if (!(e.target instanceof Konva.Image)) return;
+            if (!linkRectsToImages || imgLinkedGroups.length === 0 || !imgDragLastPos) return;
+            const img = e.target;
+            const dx = img.x() - imgDragLastPos.x;
+            const dy = img.y() - imgDragLastPos.y;
+            imgLinkedGroups.forEach(group => {
+                group.x(group.x() + dx);
+                group.y(group.y() + dy);
+            });
+            imgDragLastPos = { x: img.x(), y: img.y() };
+            polygonLayer.batchDraw();
+        });
+
         stage.on('dragend', (e) => {
             if (!(e.target instanceof Konva.Image) || !imgDragStartPos) return;
             const img = e.target;
             const start = { ...imgDragStartPos };
             const end = { x: img.x(), y: img.y() };
+            // Snapshot any linked groups so undo/redo moves them with the image
+            const linkedMoves = imgLinkedGroupStartPositions.map(s => ({
+                group: s.group,
+                start: { x: s.x, y: s.y },
+                end: { x: s.group.x(), y: s.group.y() }
+            }));
             imgDragStartPos = null;
+            imgDragLastPos = null;
+            imgLinkedGroups = [];
+            imgLinkedGroupStartPositions = [];
             if (start.x === end.x && start.y === end.y) return;
             UndoManager.push({
-                undo: () => { img.position(start); tr.forceUpdate(); stage.batchDraw(); },
-                redo: () => { img.position(end); tr.forceUpdate(); stage.batchDraw(); }
+                undo: () => {
+                    img.position(start);
+                    linkedMoves.forEach(m => m.group.position(m.start));
+                    tr.forceUpdate(); stage.batchDraw(); polygonLayer.batchDraw();
+                },
+                redo: () => {
+                    img.position(end);
+                    linkedMoves.forEach(m => m.group.position(m.end));
+                    tr.forceUpdate(); stage.batchDraw(); polygonLayer.batchDraw();
+                }
             });
         });
 

--- a/scripts/leftPanelManager.js
+++ b/scripts/leftPanelManager.js
@@ -25,6 +25,27 @@ const LeftPanelManager = {
         let drawingMode = false;
         let drawingModeHandlers = null;
 
+        let linkRectsToImages = false;
+
+        document.getElementById('linkRectsToImages').addEventListener('change', (e) => {
+            linkRectsToImages = e.target.checked;
+        });
+
+        function getOverlappingGroups(konvaImg) {
+            const imgBox = konvaImg.getClientRect();
+            const groups = [];
+            polygonLayer.find('.group').forEach(group => {
+                const groupBox = group.getClientRect();
+                if (imgBox.x + imgBox.width > groupBox.x &&
+                    imgBox.x < groupBox.x + groupBox.width &&
+                    imgBox.y + imgBox.height > groupBox.y &&
+                    imgBox.y < groupBox.y + groupBox.height) {
+                    groups.push(group);
+                }
+            });
+            return groups;
+        }
+
         // Lock/Unlock Images button
         const lockBtn = document.getElementById('lockImagesLeft');
         lockBtn.addEventListener('click', () => {
@@ -299,6 +320,49 @@ const LeftPanelManager = {
             ]
         });
         uiLayer.add(tr);
+
+        let imgDragStartPos = null;
+        let imgDragLastPos = null;
+        let imgLinkedGroups = [];
+        let imgLinkedGroupStartPositions = [];
+
+        stage.on('dragstart', (e) => {
+            if (!(e.target instanceof Konva.Image)) return;
+            const img = e.target;
+            imgDragStartPos = { x: img.x(), y: img.y() };
+            imgDragLastPos = { x: img.x(), y: img.y() };
+            if (linkRectsToImages) {
+                imgLinkedGroups = getOverlappingGroups(img);
+                imgLinkedGroupStartPositions = imgLinkedGroups.map(g => ({
+                    group: g, x: g.x(), y: g.y()
+                }));
+            } else {
+                imgLinkedGroups = [];
+                imgLinkedGroupStartPositions = [];
+            }
+        });
+
+        stage.on('dragmove', (e) => {
+            if (!(e.target instanceof Konva.Image)) return;
+            if (!linkRectsToImages || imgLinkedGroups.length === 0 || !imgDragLastPos) return;
+            const img = e.target;
+            const dx = img.x() - imgDragLastPos.x;
+            const dy = img.y() - imgDragLastPos.y;
+            imgLinkedGroups.forEach(group => {
+                group.x(group.x() + dx);
+                group.y(group.y() + dy);
+            });
+            imgDragLastPos = { x: img.x(), y: img.y() };
+            polygonLayer.batchDraw();
+        });
+
+        stage.on('dragend', (e) => {
+            if (!(e.target instanceof Konva.Image)) return;
+            imgDragStartPos = null;
+            imgDragLastPos = null;
+            imgLinkedGroups = [];
+            imgLinkedGroupStartPositions = [];
+        });
 
         // Click to select background image or polygon
         stage.on('click', (e) => {


### PR DESCRIPTION
## Summary
- "Link Rects" checkbox in left panel toolbar
- When enabled, dragging a source image moves all overlapping polygon rects with it
- Uses stage-level drag events for reliable Konva Transformer compatibility

## Test plan
- [x] Toggle on, drag image — overlapping rects move with it
- [x] Toggle off, drag image — rects stay in place
- [x] Works with multiple rects overlapping the same image

🤖 Generated with [Claude Code](https://claude.com/claude-code)