### PR TITLE
feat: add padding/margin option to AutoPack

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
             <div class="toolbar d-flex gap-2 align-items-center">
                 <label>Width: <input type="number" id="rightWidth" value="512" style="width:80px;"></label>
                 <label>Height: <input type="number" id="rightHeight" value="512" style="width:80px;"></label>
+                <label>Padding: <input type="number" id="imagesPadding" value="0" style="width:80px;"></label>
                 <button id="resizeRight" class="btn btn-sm btn-primary">Set Size</button>
                 <label class="ms-2">
 				  <input type="checkbox" id="exportTransparent" /> Transparent Background

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -35,7 +35,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Auto Pack button
     document.getElementById('autoPack').addEventListener('click', () => {
-        RightPanelManager.autoPackTextures(stageRight, false);
+        const padding = parseInt(document.getElementById('imagesPadding').value);
+        RightPanelManager.autoPackTextures(stageRight, false, undefined, padding);
     });
 
     // Export button

--- a/scripts/rightPanelManager.js
+++ b/scripts/rightPanelManager.js
@@ -478,7 +478,7 @@ const RightPanelManager = {
         }
     },
 
-    autoPackTextures: (stage, autoScale = false, scaleLimit = 0.2) => {
+    autoPackTextures: (stage, autoScale = false, scaleLimit = 0.2, padding) => {
         const tiedRects = stage.tiedRects;
         const bgRect = stage.bgRect;
         const containerWidth = bgRect.width();
@@ -489,8 +489,8 @@ const RightPanelManager = {
         const getDims = (texture, rotation = 0, scaleFactor = 1) => {
             const scaleX = (texture.scaleX() || 1) * scaleFactor;
             const scaleY = (texture.scaleY() || 1) * scaleFactor;
-            const baseWidth = texture.width() * scaleX;
-            const baseHeight = texture.height() * scaleY;
+            const baseWidth = texture.width() * scaleX + (padding / 2) ;
+            const baseHeight = texture.height() * scaleY + (padding / 2);
             if (rotation % 180 === 0) return { width: baseWidth, height: baseHeight };
             return { width: baseHeight, height: baseWidth };
         };
@@ -504,7 +504,7 @@ const RightPanelManager = {
             return Math.max(dimB.width, dimB.height) - Math.max(dimA.width, dimA.height);
         });
 
-        let freeRects = [{ x: 0, y: 0, width: containerWidth, height: containerHeight }];
+        let freeRects = [{ x: padding / 2, y: padding / 2, width: containerWidth - padding / 2, height: containerHeight - padding / 2 }];
         let packedCount = 0;
         let skippedCount = 0;
 


### PR DESCRIPTION
Add a padding/margin spinbox to the AutoPack feature. 
Allow to create a consistent separation between each texture.

| Before   | After |
| -------- | ------- |
| <img width="925" height="876" alt="before" src="https://github.com/user-attachments/assets/543f9cb0-2715-4ef0-944e-51bca1837869" />  | <img width="910" height="875" alt="after" src="https://github.com/user-attachments/assets/49c9470d-29ac-45d5-a374-ff01da8aa755" />    |

Should solve issue #26 